### PR TITLE
Add a fallback for Package.swift files

### DIFF
--- a/xcopen
+++ b/xcopen
@@ -66,10 +66,18 @@ if [ $FOUND -eq 0 ]; then
   done
 fi
 
+# If nothing was found, try to open the first Package.swift file found
+if [ $FOUND -eq 0 ]; then
+  if [ -f "$DIR/Package.swift" ]; then
+    open $APP "$i"
+    FOUND=1
+  fi
+fi
+
 shopt -u nullglob
 
 # Print message if nothing was found
 if [ $FOUND -eq 0 ]; then
-  echo "No xcworkspace/xcodeproj file found in the specified directory."
+  echo "No xcworkspace/xcodeproj/Package.swift file found in the specified directory."
   exit 1
 fi

--- a/xcopen
+++ b/xcopen
@@ -69,7 +69,7 @@ fi
 # If nothing was found, try to open the first Package.swift file found
 if [ $FOUND -eq 0 ]; then
   if [ -f "$DIR/Package.swift" ]; then
-    open $APP "$i"
+    open $APP "Package.swift"
     FOUND=1
   fi
 fi


### PR DESCRIPTION
Given that new versions of Xcode can open Package.swift files and that auto-complete isn't always your friend since Package.resolved gets created, here's a PR to make xcopen use Package.swift files too